### PR TITLE
Removes optional pinPadType parameter from theme configuration.

### DIFF
--- a/app/src/main/java/com/zoop/sdk/taponphone/sample/MainActivity.kt
+++ b/app/src/main/java/com/zoop/sdk/taponphone/sample/MainActivity.kt
@@ -12,7 +12,6 @@ import androidx.lifecycle.lifecycleScope
 import androidx.lifecycle.repeatOnLifecycle
 import com.zoop.sdk.plugin.taponphone.api.InitializationRequest
 import com.zoop.sdk.plugin.taponphone.api.PaymentType
-import com.zoop.sdk.plugin.taponphone.api.PinPadType
 import com.zoop.sdk.plugin.taponphone.api.TapOnPhoneTheme
 import com.zoop.sdk.taponphone.sample.databinding.ActivityMainBinding
 import kotlinx.coroutines.launch
@@ -148,7 +147,6 @@ class MainActivity : AppCompatActivity() {
             amountTextColor = null, // Default is android:textColor from theme.xml
             paymentTypeTextColor = null, // Default is android:textColor from theme.xml
             statusTextColor = null,
-            pinPadType = PinPadType.STANDARD,
         )
     }
 }


### PR DESCRIPTION
### **PR Type**
Enhancement


___

### **Description**
- Removeu o parâmetro opcional `pinPadType` da configuração do tema `TapOnPhoneTheme`
- Simplificou a configuração do tema ao remover uma opção que não era mais necessária
- Atualizou o código para refletir as mudanças na API do SDK


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>MainActivity.kt</strong><dd><code>Remoção do parâmetro pinPadType da configuração do tema</code>&nbsp; &nbsp; </dd></summary>
<hr>

app/src/main/java/com/zoop/sdk/taponphone/sample/MainActivity.kt

<li>Removeu a importação de <code>PinPadType</code><br> <li> Removeu o parâmetro <code>pinPadType</code> da configuração do tema <code>TapOnPhoneTheme</code><br> <br>


</details>


  </td>
  <td><a href="https://github.com/getzoop/zoop-sample-taponphone-android/pull/10/files#diff-34c6c9636d53a181896f4b8065bd85ebdd6492db3d428db58e847b1e73a24c75">+0/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

